### PR TITLE
Changed tagline, iOS to Windows

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,8 +7,8 @@ permalink:        pretty
 
 # Setup
 title:            Wired In
-tagline:          'A modern productivity tool for Mac, iOS & your desk.'
-description:      'A modern productivity tool for Mac, iOS & your desk.'
+tagline:          'A modern productivity tool for Mac, Windows & your desk.'
+description:      'A modern productivity tool for Mac, Windows & your desk.'
 url:              http://blog.wearewired.In
 
 author:


### PR DESCRIPTION
replacing the 'iOS' in the tagline to be 'Windows' since that is what we have at the moment.